### PR TITLE
Use API Token instead of basic authentication with password.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ Add step definition.
           inputs:
             - host: $JIRA_HOST
             - user: $JIRA_USER
-            - password: $JIRA_PASSWORD
+            - api_token: $JIRA_API_TOKEN
             - qa_transition_id: $JIRA_QA_TRANSACTION_ID
             - no_qa_transition_id: $JIRA_NO_QA_TRANSACTION_ID
 ```
-Provide correct user and password. 
+Provide correct user and api token. 
 To findout correct transtion id run 
 ```bash
-curl -D- -u user:password -X GET JIRA_HOST/rest/api/2/issue/JIRA_ISSUE/transitions
+curl -D- -u user:api_token -X GET JIRA_HOST/rest/api/2/issue/JIRA_ISSUE/transitions
 ```
 
 As a $JIRA_ISSUE(format: XXX-1234) use id for the ticket that is currently in code review column

--- a/step.sh
+++ b/step.sh
@@ -42,14 +42,14 @@ echo $comment_body
 comment_url=$host/rest/api/2/issue/$jira_issue/comment
 echo "$comment_url"
 # add comment
-curl -D- -o /dev/null -u $user:$password -X POST -H "Content-Type: application/json" -d "{\"body\": \"$comment_body\"}" $comment_url
+curl -D- -o /dev/null -u $user:$api_token -X POST -H "Content-Type: application/json" -d "{\"body\": \"$comment_body\"}" $comment_url
 
 transition_url=$host/rest/api/2/issue/$jira_issue/transitions
 echo "$transition_url"
 # move to ready for qa
-res=$( curl -w %{http_code} -s --output /dev/null -D- -u $user:$password -X POST -H "Content-Type: application/json" -d "{\"transition\": {\"id\" : \"$qa_transition_id\"} }" $transition_url)
+res=$( curl -w %{http_code} -s --output /dev/null -D- -u $user:$api_token -X POST -H "Content-Type: application/json" -d "{\"transition\": {\"id\" : \"$qa_transition_id\"} }" $transition_url)
 
 # if task was no_qa move directly to client
 if [ "$res" != "204" ]; then
-	curl -D- -o /dev/null -u $user:$password -X POST -H "Content-Type: application/json" -d "{\"transition\": {\"id\" : \"$no_qa_transition_id\"} }" $host/rest/api/2/issue/$jira_issue/transitions
+	curl -D- -o /dev/null -u $user:$api_token -X POST -H "Content-Type: application/json" -d "{\"transition\": {\"id\" : \"$no_qa_transition_id\"} }" $host/rest/api/2/issue/$jira_issue/transitions
 fi

--- a/step.yml
+++ b/step.yml
@@ -49,12 +49,13 @@ inputs:
       is_expand: true
       is_required: true
       value_options: []
-  - password:
+  - api_token:
     opts:
-      title: "JIRA Password"
-      summary: Password for supplied user
+      title: "JIRA API Token"
+      summary: Token created for supplied user
       description: |
-        Password is used to authenticate with JIRA API
+        API token is used to authenticate with JIRA API. 
+        It can be created here: https://id.atlassian.com/manage/api-tokens?_ga=2.43946604.875494627.1562923837-75487430.1434788493
       is_expand: true
       is_required: true
       value_options: []


### PR DESCRIPTION
Recently JIRA has deprecated using basic authentication with password.
https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-basic-auth-and-cookie-based-auth/
This PR introduces breaking changes:
- `password` param was renamed to `api_token`