### PR TITLE
Allow providing core data

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -12,7 +12,11 @@ if [ -z "$add_bitrise_public_download_url" ]; then
 fi
 
 if [ -z "$pull_request_id" ]; then
-	add_bitrise_public_download_url=true
+	echo "pull_request_id not set"
+fi
+
+if [ -z "$jira_issue" ]; then
+	echo "jira_issue not set"
 fi
 
 # When either is unset

--- a/step.sh
+++ b/step.sh
@@ -11,19 +11,9 @@ if [ -z "$add_bitrise_public_download_url" ]; then
 	add_bitrise_public_download_url=true
 fi
 
-echo "pull request id: $pull_request_id"
-echo "jira issue: $jira_issue"
-
-if [ -z "$pull_request_id" ]; then
-	echo "pull_request_id not set"
-fi
-
-if [ -z "$jira_issue" ]; then
-	echo "jira_issue not set"
-fi
-
 # When either is unset
 if [ -z "$pull_request_id" ] || [ -z "$jira_issue" ]; then
+	echo "Extracting values from merge commit message."
 	# Check if this is merge commit
 	if [[ $BITRISE_GIT_MESSAGE != *"Merge pull request"* ]]; then
 		echo "This commit it's not a merge commit"

--- a/step.sh
+++ b/step.sh
@@ -11,6 +11,9 @@ if [ -z "$add_bitrise_public_download_url" ]; then
 	add_bitrise_public_download_url=true
 fi
 
+echo "pull request id: $pull_request_id"
+echo "jira issue: $jira_issue"
+
 if [ -z "$pull_request_id" ]; then
 	echo "pull_request_id not set"
 fi

--- a/step.yml
+++ b/step.yml
@@ -68,6 +68,28 @@ inputs:
       is_expand: true
       is_required: true
       value_options: []
+  - pull_request_id:
+    opts:
+      title: "Pull Request number"
+      summary: |
+        When provided along with jira issue value, step will not try to extract those values automatically.
+        Provide those values when build was not triggered by merge commit.
+      description: |
+        ex.: 111
+      is_expand: true
+      is_required: false
+      value_options: []   
+  - jira_issue:
+    opts:
+      title: "JIRA Issue ID"
+      summary: |
+        When provided along with Pull Request number issue value, step will not try to extract those values automatically.
+        Provide those values when build was not triggered by merge commit.
+      description: |
+        ex.: ASD-123
+      is_expand: true
+      is_required: false
+      value_options: []     
   - qa_transition_id:
     opts:
       title: "JIRA QA transition ID"


### PR DESCRIPTION
There is possibility to provide data like pull request number and jira issue id, so the step will not try to extract them from merge commit. This can be useful, when you try to trigger action not on merge Pull Request event.